### PR TITLE
Redirect to establishment specific page after accepting invitation

### DIFF
--- a/lib/pages/register/index.js
+++ b/lib/pages/register/index.js
@@ -51,7 +51,7 @@ module.exports = settings => {
   // TODO: Add middleware which polls the database to check permission has been set
 
   app.post('/', (req, res, next) => {
-    res.redirect(settings.client);
+    res.redirect(`${settings.client}?establishment=${req.model.establishmentId}`);
   });
 
   return app;


### PR DESCRIPTION
If a user is accepting an invitation to a second establishment then we should make sure that we redirect to the right establishment's landing page.