### PR TITLE
Reverse order of page headings

### DIFF
--- a/lib/pages/register/views/existing.jsx
+++ b/lib/pages/register/views/existing.jsx
@@ -6,8 +6,8 @@ import Snippet from '@asl/pages/pages/common/views/containers/snippet';
 const Page = ({ establishmentName }) => (
   <FormLayout>
     <header>
-      <h2><Snippet>existingUser</Snippet></h2>
-      <h1>{establishmentName}</h1>
+      <h2>{establishmentName}</h2>
+      <h1><Snippet>existingUser</Snippet></h1>
     </header>
     <Inset>
       <Snippet>acceptInvitation</Snippet>

--- a/lib/pages/register/views/index.jsx
+++ b/lib/pages/register/views/index.jsx
@@ -11,8 +11,8 @@ const Page = ({
 }) => (
   <FormLayout>
     <header>
-      <h2><Snippet>createAccount</Snippet></h2>
-      <h1>{establishmentName}</h1>
+      <h2>{establishmentName}</h2>
+      <h1><Snippet>createAccount</Snippet></h1>
     </header>
     <div className="panel panel-wide">
       <Snippet email={email}>account.setup</Snippet>


### PR DESCRIPTION
For consistency with main app swap headings to be h2 - establishment name, h1 - page title